### PR TITLE
Add un-interactive auth

### DIFF
--- a/crunchy.js
+++ b/crunchy.js
@@ -66,6 +66,8 @@ let argv = yargs
     .help(false).version(false)
     // auth
     .describe('auth','Enter auth mode')
+    .describe('user','Username used for un-interactive authentication (Used with --auth)')
+    .describe('pass','Password used for un-interactive authentication (Used with --auth)')
     // fonts
     .describe('dlfonts','Download all required fonts for mkv muxing')
     // search
@@ -220,8 +222,8 @@ const usefulCookies = {
 // auth method
 async function doAuth(){
     console.log('[INFO] Authentication');
-    const iLogin = await shlp.question('[Q] LOGIN/EMAIL');
-    const iPsswd = await shlp.question('[Q] PASSWORD   ');
+    const iLogin = argv.user ? argv.user : await shlp.question('[Q] LOGIN/EMAIL');
+    const iPsswd = argv.pass ? argv.pass : await shlp.question('[Q] PASSWORD   ');
     const authData = new URLSearchParams({
         name: iLogin,
         password: iPsswd

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,8 @@ After installing NodeJS with NPM go to directory with `package.json` file and ty
 ### Authentication
 
 * `--auth` enter auth mode
+* `--user <user>` skip the username dialog in auth mode (optional)
+* `--pass <pass>` skip the password dialog in auth mode (optional)
 
 ### Fonts
 


### PR DESCRIPTION
This can be used for automating the auth due to CR making cookies expire every few days.

This isn't a requirement to use these options, all they do is skip the user input of the username and password dialogs in auth mode meaning you could auth in crontab every other day to ensure that you have updated cookies.